### PR TITLE
Fixed the conditional statement to correctly convert when keyNum is 0.

### DIFF
--- a/CogInventory.js
+++ b/CogInventory.js
@@ -69,7 +69,7 @@ class Cog {
   position(keyNum) {
     const isDefault = keyNum === undefined;
     if (this._position && isDefault) return this._position;
-    keyNum = keyNum || Number.parseInt(this.key);
+    keyNum = isNaN(keyNum) ? Number.parseInt(this.key) : keyNum;
     // board = 0-95
     // build = 96-107
     // spare = 108-*


### PR DESCRIPTION
Fix #1 
I have fixed the bug reported in #1.

Since Boolean(0) returns false, the following code was returning Number.parseInt(this.key) when keyNum is 0:
```js
keyNum = keyNum || Number.parseInt(this.key);
```
However, I think this behaviour is wrong. I have changed this conditional statement to the correct one:
```js
keyNum = isNaN(keyNum) ? Number.parseInt(this.key) : keyNum;
```