### PR TITLE
Fix typo in optimizer causing corners cog boost to be ignored

### DIFF
--- a/CogInventory.js
+++ b/CogInventory.js
@@ -370,7 +370,7 @@ class CogInventory {
             boosted.push([k, j]);
           }
           break;
-        case "corner":
+        case "corners":
           boosted.push([i-2, j-2],[i-2, j+2],[i+2, j-2],[i+2, j+2]);
           break;
         case "around":


### PR DESCRIPTION
I found a bug in the optimizer where the boost for the corners cog was not being considered. 
The cause was a typo where "corners" was mistakenly written as "corner". 
With this fix, I have confirmed locally that the optimizer now correctly considers the corners cog.